### PR TITLE
Search

### DIFF
--- a/src/controllers/productsController.ts
+++ b/src/controllers/productsController.ts
@@ -3,7 +3,7 @@ import pool from '../config/db';
 // import {Product, VariantImage, BasicProductVariant, UpdatedProduct, UpdateProduct, UpdateVariantImage, UpdateProductVariant, BasicProduct } from "../types/product";
 // import { getProductProfile, createProduct, updateProduct, createProductVariant, updateProductVariant, createProductImage, updateProductImage, getStoreId, getProductId, deleteProduct, deleteVariant, deleteVariantImage, getHotProducts } from "../services/productsService";
 import { Product } from "../types/product";
-import { getHotProducts, getProductProfile, getReviews, getReviewsByStar, getReviewsThatHaveComment, getReviewsThatHaveImage } from "../services/productsService";
+import { getHotProducts, getProductProfile, getReviews, getReviewsByStar, getReviewsThatHaveComment, getReviewsThatHaveImage, searchProducts } from "../services/productsService";
 import { checkStoreOwner } from "../services/storeService";
 
 export const getHot = async (req: Request, res: Response) => {
@@ -391,5 +391,25 @@ export const getProductReviewsHaveImage = async (req: Request, res: Response) =>
     } catch (err) {
         console.error("Error fetching product reviews with images", err);
         res.status(500).json({ error: "Error fetching product reviews with images" });
+    }
+};
+
+export const searchForProducts = async (req: Request, res: Response): Promise<void> => {
+    const query = req.query.q as string;
+    const limit: number = Number(req.query.limit) || 20;
+    const offset: number = Number(req.query.offset) || 0;
+
+    if (!query) {
+        // Use return to exit the function early
+        res.status(400).json({ error: 'Search query is required' });
+        return; 
+    }
+
+    try {
+        const products: Product[] = await searchProducts(query, limit, offset);
+        res.status(200).json(products);
+    } catch (err) {
+        console.error('Error searching for products', err);
+        res.status(500).json({ error: 'Error searching for products' });
     }
 };

--- a/src/routes/productRoutes.ts
+++ b/src/routes/productRoutes.ts
@@ -1,12 +1,19 @@
 import express from "express";
 // import { addVariant, addVariantImage, createAProduct, deleteImage, deleteProductProfile, deleteVariantProfile, getHot, getProductById, updateAProduct, updateVariant, updateVariantImage } from "../controllers/productsController";
-import { getHot, getProductById, getProductReviews, getProductReviewsByStar, getProductReviewsHaveComment, getProductReviewsHaveImage } from "../controllers/productsController";
+import { getHot, getProductById, getProductReviews, getProductReviewsByStar, getProductReviewsHaveComment, getProductReviewsHaveImage, searchForProducts } from "../controllers/productsController";
 import { authenticateToken } from "../middlewares/authenticateToken";
 import { authorizeRole } from "../middlewares/authorizationRole";
 
 const router = express.Router();
 
+// Search
+router.get('/search', searchForProducts);
+
+
 router.get('/hot', getHot);
+
+
+
 router.get('/:id', getProductById);
 /*
 router.post('/create', authenticateToken, authorizeRole(['seller', 'admin']), createAProduct);
@@ -25,5 +32,6 @@ router.get('/:id/reviews', getProductReviews);
 router.get('/:id/reviews/rating/:rating', getProductReviewsByStar);
 router.get('/:id/reviews/comment', getProductReviewsHaveComment);
 router.get('/:id/reviews/image', getProductReviewsHaveImage);
+
 
 export default router;


### PR DESCRIPTION
- Add search route

Example:
You can now make a GET request to your new search endpoint from your front-end application:
GET /products/search?q=your-search-term

For example, to search for "red dress", the request would be:
GET /products/search?q=red%20dress

You can also include limit and offset for pagination:
GET /products/search?q=red%20dress&limit=10&offset=20