### PR TITLE
Disable Provenance on Docker Image push in GitHub Actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           context: .
           push: true
+          provenance: false
           platforms: linux/amd64, linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
By default, the GitHub Actions config produces an image artifact of the architecture `unknown/unknown`, which does nothing. Turning off Provenance during the provisioning and pushing of the Docker Image gets rid of this issue, while making our container image more OCI-compliant.